### PR TITLE
#168260523 Create an error alert box

### DIFF
--- a/templates/js/alert.js
+++ b/templates/js/alert.js
@@ -9,7 +9,7 @@ function CustomAlert() {
             dialogoverlay.style.display = "block";
             dialogoverlay.style.height = winH + "px";
             dialogbox.style.left = "30px";
-            dialogbox.style.top = "120px";
+            dialogbox.style.top = "121px";
             dialogbox.style.display = "block";
             dialogbox.style.width = winW / 2 + "px";
             document.getElementById("dialogboxhead").innerHTML =

--- a/templates/js/flag_alert.js
+++ b/templates/js/flag_alert.js
@@ -1,0 +1,25 @@
+function CustomAlert() {
+    this.render = function(dialog) {
+        var winW = window.innerWidth;
+        var winH = window.innerHeight;
+        var dialogoverlay = document.getElementById("dialogoverlay");
+        var dialogbox = document.getElementById("dialogbox");
+
+        dialogoverlay.style.display = "block";
+        dialogoverlay.style.height = winH + "px";
+        dialogbox.style.left = "30px";
+        dialogbox.style.top = "120px";
+        dialogbox.style.display = "block";
+        dialogbox.style.width = winW / 2 + "px";
+        document.getElementById("dialogboxhead").innerHTML =
+            "Click 'OK' to flag this article";
+        document.getElementById("dialogboxbody").innerHTML = dialog;
+        document.getElementById("dialogboxfoot").innerHTML =
+            '<button id="button" onclick="Alert.ok()">OK</button>';
+    };
+    this.ok = function() {
+        document.getElementById("dialogbox").style.display = "none";
+        document.getElementById("dialogoverlay").style.display = "none";
+    };
+}
+const Alert = new CustomAlert();


### PR DESCRIPTION
#### What does this PR do?
Have an error/ flag alert box pop up once a user executes a forbidden command
The PR merges the content from the ch-error-alert-box-168260523 branch with the develop branch.

#### Description of Tasks to be completed?

- Add javascript to enable the error alert pop up
- Add styling to the error alert box
- Add a style to display the hamburger menu bar in less than 700px
- Create a convenient and responsive display unit
- Set-up a button to click and allow continual of page operations

#### How should this be manually tested?
After cloning this repository, right-click on the reset_password.html file and select open with chrome browser. Once open, try clicking the reset-password button without updating assigning a value to the email form section.

What is the relevant pivotal tracker story?
#168260523

ScreenShot
![Uploading image.png…]()
